### PR TITLE
Add button to download draft results as a text file

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
     const NUM_PLAYERS = 6;
     const NUM_PACKS = 3;
-    const CARDS_PER_PACK = 1;
+    const CARDS_PER_PACK = 15;
     const DEFAULT_CUBE_FILE = "winstons_cube_3-4-2016.txt";
     var cubeList;
     var packs;
@@ -267,3 +267,4 @@
 
     </body>
     </html>
+	

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
     const NUM_PLAYERS = 6;
     const NUM_PACKS = 3;
-    const CARDS_PER_PACK = 15;
+    const CARDS_PER_PACK = 1;
     const DEFAULT_CUBE_FILE = "winstons_cube_3-4-2016.txt";
     var cubeList;
     var packs;
@@ -163,7 +163,7 @@
       playerPickDivs.forEach(function(pickDiv) {
         pickDiv.style.display = 'block';
       })
-      
+
       // Display text list of all picks
       var allPicks = document.createElement("textarea");
 	  allPicks.setAttribute("id","PicksToText");
@@ -191,17 +191,18 @@
 	  var downloadButton = document.createElement("input");
 	  downloadButton.type = "button";
 	  downloadButton.value = "Download!";
-	  downloadButton.onClick = downloadPicks;
+	  var pickValues = document.getElementById('PicksToText').value;
+	  downloadButton.addEventListener('click', function() { downloadPicks(pickValues); },false);
+	  document.body.insertBefore(downloadButton, null);
     }
 
-	//Get the contents of the PicksToText text box and download them as a text file
-	function downloadPicks()
+	//Get the contents of the a string and download them as a text file
+	function downloadPicks(pickInfo)
 	{
-		var pickValues = document.getElementById('PicksToText').value;
-		window.open('data:text/csv,' + encodeURIComponent(pickValues))
-		
+		console.log("User asked to download draft information.");
+		window.open('data:text/csv,' + encodeURIComponent(pickInfo))
 	}
-	
+
     function getActivePack() {
       console.log(`currentPack: ${currentPack} currentSeat : ${currentSeat} currentPick: ${currentPick}`);
       var direction = (currentPack % 2 == 0) ? 1 : -1;
@@ -258,7 +259,7 @@
     <body>
 
     <input type='file' accept='text/plain' onchange='initializeFromFile(event)'><br>
-	
+
     <p>Current Pack</p>
     <div id="display"></div>
     <div id="picksDisplay"></div>

--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
       
       // Display text list of all picks
       var allPicks = document.createElement("textarea");
+	  allPicks.setAttribute("id","PicksToText");
       allPicks.setAttribute("readonly", "");
       allPicks.setAttribute("rows", "8");
       allPicks.setAttribute("cols", "50");
@@ -185,8 +186,22 @@
       }
       allPicks.textContent += allPicksText;
       document.body.insertBefore(allPicks, null);
+	  
+	  //Create button to allow users to download draft information.
+	  var downloadButton = document.createElement("input");
+	  downloadButton.type = "button";
+	  downloadButton.value = "Download!";
+	  downloadButton.onClick = downloadPicks;
     }
 
+	//Get the contents of the PicksToText text box and download them as a text file
+	function downloadPicks()
+	{
+		var pickValues = document.getElementById('PicksToText').value;
+		window.open('data:text/csv,' + encodeURIComponent(pickValues))
+		
+	}
+	
     function getActivePack() {
       console.log(`currentPack: ${currentPack} currentSeat : ${currentSeat} currentPick: ${currentPick}`);
       var direction = (currentPack % 2 == 0) ? 1 : -1;
@@ -195,7 +210,7 @@
       console.log("activePack:" + index);
       return packs[index];
     }
-
+	
     function toggleDisplay(element) {
       if(element.style.display !== 'none') {
         element.style.display = 'none';
@@ -243,7 +258,7 @@
     <body>
 
     <input type='file' accept='text/plain' onchange='initializeFromFile(event)'><br>
-
+	
     <p>Current Pack</p>
     <div id="display"></div>
     <div id="picksDisplay"></div>


### PR DESCRIPTION
Adds a button to download the draft results as a text file. Tested on Chrome.
